### PR TITLE
Changed File path from id_partition to id to support the old cms file paths | Target : 1.12

### DIFF
--- a/app/models/comfy/cms/file.rb
+++ b/app/models/comfy/cms/file.rb
@@ -16,8 +16,8 @@ class Comfy::Cms::File < ActiveRecord::Base
         ).merge(ComfortableMexicanSofa.config.upload_file_options[:styles] || {})
       end
     },
-    :path => ':rails_root/public/system/cms/files/:id_partition/files/:style/:filename',
-    :url => '/system/cms/files/:id_partition/files/:style/:filename',
+    :path => ':rails_root/public/system/cms/files/:id/files/:style/:filename',
+    :url => '/system/cms/files/:id/files/:style/:filename',
   )
   before_post_process :is_image?
 


### PR DESCRIPTION

Changed File path from id_partition to id to support the old cms file paths.